### PR TITLE
feat: add acceptJSONP and open jsonp wrap function

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,10 @@ see [config/config.default.js](https://github.com/eggjs/egg-jsonp/blob/master/co
 ## API
 
 * ctx.acceptJSONP - detect if response should be jsonp, readonly
-* ctx.wrapJsonp(body) - wrap data to jsonp
+* ctx.wrapJSONP(body) - wrap data to jsonp
 
 ```js
- ctx.wrapJsonp({msg: 'error message'}); // this.body = fn({msg: 'error message'})
+ ctx.wrapJSONP({ msg: 'error message' }); // this.body = fn({ msg: 'error message' })
 ```
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ exports.jsonp = {
 
 see [config/config.default.js](https://github.com/eggjs/egg-jsonp/blob/master/config/config.default.js) for more detail.
 
+## API
+
+* ctx.acceptJSONP - detect if response should be jsonp, readonly
+* ctx.wrapJsonp(body) - wrap data to jsonp
+
+```js
+ ctx.wrapJsonp({msg: 'error message'}); // this.body = fn({msg: 'error message'})
+```
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,6 @@ see [config/config.default.js](https://github.com/eggjs/egg-jsonp/blob/master/co
 ## API
 
 * ctx.acceptJSONP - detect if response should be jsonp, readonly
-* ctx.wrapJSONP(body) - wrap data to jsonp
-
-```js
- ctx.wrapJSONP({ msg: 'error message' }); // this.body = fn({ msg: 'error message' })
-```
 
 ## Example
 

--- a/app/extend/application.js
+++ b/app/extend/application.js
@@ -2,7 +2,7 @@
 
 const is = require('is-type-of');
 const url = require('url');
-const JSONP_CONFIG = require('../../lib/private_key').JSONP_CONFIG;
+const { JSONP_CONFIG, JSONP_WRAPPER } = require('../../lib/private_key');
 
 module.exports = {
   /**
@@ -64,7 +64,7 @@ module.exports = {
       yield next;
 
       // generate jsonp body
-      this.wrapJSONP(this.body);
+      this[JSONP_WRAPPER](this.body);
     };
   },
 };

--- a/app/extend/application.js
+++ b/app/extend/application.js
@@ -2,7 +2,7 @@
 
 const is = require('is-type-of');
 const url = require('url');
-const JSONP_CONFIG = Symbol.for('jsonp#config');
+const JSONP_CONFIG = require('../../lib/private_key').JSONP_CONFIG;
 
 module.exports = {
   /**
@@ -64,7 +64,7 @@ module.exports = {
       yield next;
 
       // generate jsonp body
-      this.wrapJsonp(this.body);
+      this.wrapJSONP(this.body);
     };
   },
 };

--- a/app/extend/application.js
+++ b/app/extend/application.js
@@ -18,8 +18,8 @@ module.exports = {
     if (!Array.isArray(options.callback)) options.callback = [ options.callback ];
 
     const csrfEnable = this.plugins.security && this.plugins.security.enable // security enable
-       && this.config.security.csrf && this.config.security.csrf.enable !== false // csrf enable
-      && options.csrf;  // jsonp csrf enabled
+      && this.config.security.csrf && this.config.security.csrf.enable !== false // csrf enable
+      && options.csrf; // jsonp csrf enabled
 
     const validateReferrer = options.whiteList && createValidateReferer(options.whiteList);
 
@@ -63,7 +63,7 @@ module.exports = {
 
       yield next;
 
-       // generate jsonp body
+      // generate jsonp body
       this.wrapJsonp(this.body);
     };
   },

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const jsonpBody = require('jsonp-body');
-const JSONP_CONFIG = Symbol.for('jsonp#config');
+const JSONP_CONFIG = require('../../lib/private_key').JSONP_CONFIG;
 
 module.exports = {
   /**
@@ -13,11 +13,11 @@ module.exports = {
 
   /**
    * jsonp wrap body function
-   * set jonsp response wrap function, othen plugin can use it.
+   * set jsonp response wrap function, other plugin can use it.
    * @param {Object} body respones body
    * @public
    */
-  wrapJsonp(body) {
+  wrapJSONP(body) {
     const jsonpConfig = this[JSONP_CONFIG];
     if (!jsonpConfig || !jsonpConfig.jsonpFunction) {
       this.body = body;

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const jsonpBody = require('jsonp-body');
-const JSONP_CONFIG = require('../../lib/private_key').JSONP_CONFIG;
+const { JSONP_CONFIG, JSONP_WRAPPER } = require('../../lib/private_key');
 
 module.exports = {
   /**
@@ -17,7 +17,7 @@ module.exports = {
    * @param {Object} body respones body
    * @public
    */
-  wrapJSONP(body) {
+  [JSONP_WRAPPER](body) {
     const jsonpConfig = this[JSONP_CONFIG];
     if (!jsonpConfig || !jsonpConfig.jsonpFunction) {
       this.body = body;

--- a/app/extend/context.js
+++ b/app/extend/context.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const jsonpBody = require('jsonp-body');
+const JSONP_CONFIG = Symbol.for('jsonp#config');
+
+module.exports = {
+  /**
+   * detect if response should be jsonp
+   */
+  get acceptJSONP() {
+    return !!(this[JSONP_CONFIG] && this[JSONP_CONFIG].jsonpFunction);
+  },
+
+  /**
+   * jsonp wrap body function
+   * set jonsp response wrap function, othen plugin can use it.
+   * @param {Object} body respones body
+   * @public
+   */
+  wrapJsonp(body) {
+    const jsonpConfig = this[JSONP_CONFIG];
+    if (!jsonpConfig || !jsonpConfig.jsonpFunction) {
+      this.body = body;
+      return;
+    }
+
+    this.set('x-content-type-options', 'nosniff');
+    this.type = 'js';
+    body = body === undefined ? null : body;
+    // protect from jsonp xss
+    this.body = jsonpBody(body, jsonpConfig.jsonpFunction, jsonpConfig.options);
+  },
+};

--- a/lib/private_key.js
+++ b/lib/private_key.js
@@ -1,0 +1,3 @@
+'use strict';
+
+exports.JSONP_CONFIG = Symbol('jsonp#config');

--- a/lib/private_key.js
+++ b/lib/private_key.js
@@ -1,3 +1,4 @@
 'use strict';
 
 exports.JSONP_CONFIG = Symbol('jsonp#config');
+exports.JSONP_WRAPPER = Symbol.for('jsonp#wrapper');

--- a/package.json
+++ b/package.json
@@ -19,17 +19,17 @@
     "security"
   ],
   "dependencies": {
-    "is-type-of": "^1.0.0",
+    "is-type-of": "^1.2.0",
     "jsonp-body": "^1.0.0"
   },
   "devDependencies": {
-    "autod": "^2.8.0",
-    "egg": "^1.4.0",
-    "egg-bin": "^3.4.1",
-    "egg-ci": "^1.6.0",
-    "egg-mock": "^3.7.1",
-    "eslint": "^3.19.0",
-    "eslint-config-egg": "^4.2.0",
+    "autod": "^2.9.0",
+    "egg": "^1.8.0",
+    "egg-bin": "^4.3.2",
+    "egg-ci": "^1.8.0",
+    "egg-mock": "^3.12.1",
+    "eslint": "^4.7.1",
+    "eslint-config-egg": "^5.1.1",
     "supertest": "^3.0.0",
     "webstorm-disable-index": "^1.2.0"
   },
@@ -44,14 +44,6 @@
     "ci": "npm run lint && npm run cov",
     "autod": "autod"
   },
-  "files": [
-    "index.js",
-    "app.js",
-    "agent.js",
-    "config",
-    "app",
-    "lib"
-  ],
   "ci": {
     "version": "6, 7, 8"
   },

--- a/test/fixtures/jsonp-test/app/controller/jsonp.js
+++ b/test/fixtures/jsonp-test/app/controller/jsonp.js
@@ -5,3 +5,12 @@ exports.index = function*() {
 };
 
 exports.empty = function*() {};
+
+
+exports.mark = function*() {
+  this.body = { jsonpFunction: this.acceptJSONP };
+};
+
+exports.error = function*() {
+  throw new Error('jsonpFunction is error');
+};

--- a/test/fixtures/jsonp-test/app/router.js
+++ b/test/fixtures/jsonp-test/app/router.js
@@ -15,7 +15,7 @@ module.exports = app => {
     try {
       yield next;
     } catch (error) {
-      this.wrapJSONP({ msg: error.message });
+      this[Symbol.for('jsonp#wrapper')]({ msg: error.message });
     }
    }, app.jsonp(), 'jsonp.error');
 };

--- a/test/fixtures/jsonp-test/app/router.js
+++ b/test/fixtures/jsonp-test/app/router.js
@@ -10,4 +10,12 @@ module.exports = app => {
   app.get('/referrer/regexp', app.jsonp({ whiteList: [/https?:\/\/test\.com\//, /https?:\/\/foo\.com\//] }), 'jsonp.index');
   app.get('/csrf', app.jsonp({ csrf: true }), 'jsonp.index');
   app.get('/both', app.jsonp({ csrf: true, whiteList: 'test.com' }), 'jsonp.index');
+  app.get('/mark', app.jsonp(), 'jsonp.mark');
+  app.get('/error', function*(next) {
+    try {
+      yield next;
+    } catch (error) {
+      this.wrapJsonp({ msg: error.message });
+    }
+   }, app.jsonp(), 'jsonp.error');
 };

--- a/test/fixtures/jsonp-test/app/router.js
+++ b/test/fixtures/jsonp-test/app/router.js
@@ -15,7 +15,7 @@ module.exports = app => {
     try {
       yield next;
     } catch (error) {
-      this.wrapJsonp({ msg: error.message });
+      this.wrapJSONP({ msg: error.message });
     }
    }, app.jsonp(), 'jsonp.error');
 };

--- a/test/jsonp.test.js
+++ b/test/jsonp.test.js
@@ -190,4 +190,25 @@ describe('test/jsonp.test.js', () => {
     .expect(403)
     .expect(/jsonp request security validate failed/);
   });
+
+  it('should pass and return is a jsonp function', function* () {
+    yield request(app.callback())
+      .get('/mark?_callback=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"jsonpFunction":true});');
+  });
+
+  it('should pass and return is not a jsonp function', function* () {
+    yield request(app.callback())
+      .get('/mark')
+      .expect(200)
+      .expect({ jsonpFunction: false });
+  });
+
+  it('should pass and return error message', function* () {
+    yield request(app.callback())
+      .get('/error?_callback=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"msg":"jsonpFunction is error"});');
+  });
 });

--- a/test/jsonp.test.js
+++ b/test/jsonp.test.js
@@ -17,178 +17,178 @@ describe('test/jsonp.test.js', () => {
 
   it('should support json', function* () {
     yield request(app.callback())
-    .get('/default')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/default')
+      .expect(200)
+      .expect({ foo: 'bar' });
   });
 
   it('should support jsonp', function* () {
     yield request(app.callback())
-    .get('/default?callback=fn')
-    .expect(200)
-    .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});');
+      .get('/default?callback=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});');
   });
 
   it('should support _callback', function* () {
     yield request(app.callback())
-    .get('/default?_callback=fn')
-    .expect(200)
-    .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});');
+      .get('/default?_callback=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});');
   });
 
   it('should support jsonp if response is empty', function* () {
     yield request(app.callback())
-    .get('/empty?callback=fn')
-    .expect(200)
-    .expect('/**/ typeof fn === \'function\' && fn(null);');
+      .get('/empty?callback=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn(null);');
   });
 
   it('should not support jsonp if not use jsonp middleware', function* () {
     yield request(app.callback())
-    .get('/disable?_callback=fn')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/disable?_callback=fn')
+      .expect(200)
+      .expect({ foo: 'bar' });
   });
 
   it('should not support cutom callback name', function* () {
     yield request(app.callback())
-    .get('/fn?fn=fn')
-    .expect(200)
-    .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});');
+      .get('/fn?fn=fn')
+      .expect(200)
+      .expect('/**/ typeof fn === \'function\' && fn({"foo":"bar"});');
   });
 
   it('should not pass csrf', function* () {
     yield request(app.callback())
-    .get('/csrf')
-    .expect(403);
+      .get('/csrf')
+      .expect(403);
   });
 
   it('should pass csrf with cookie', function* () {
     yield request(app.callback())
-    .get('/csrf')
-    .set('cookie', 'csrfToken=token;')
-    .set('x-csrf-token', 'token')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/csrf')
+      .set('cookie', 'csrfToken=token;')
+      .set('x-csrf-token', 'token')
+      .expect(200)
+      .expect({ foo: 'bar' });
   });
 
   it('should pass csrf with cookie and support jsonp', function* () {
     yield request(app.callback())
-    .get('/csrf')
-    .set('cookie', 'csrfToken=token;')
-    .set('x-csrf-token', 'token')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/csrf')
+      .set('cookie', 'csrfToken=token;')
+      .set('x-csrf-token', 'token')
+      .expect(200)
+      .expect({ foo: 'bar' });
   });
 
   it('should pass referrer white list check with subdomain', function* () {
     yield request(app.callback())
-    .get('/referrer/subdomain')
-    .set('referrer', 'http://test.com/')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/referrer/subdomain')
+      .set('referrer', 'http://test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
 
     yield request(app.callback())
-    .get('/referrer/subdomain')
-    .set('referrer', 'http://sub.test.com/')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/referrer/subdomain')
+      .set('referrer', 'http://sub.test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
 
     yield request(app.callback())
-    .get('/referrer/subdomain')
-    .set('referrer', 'https://sub.sub.test.com/')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/referrer/subdomain')
+      .set('referrer', 'https://sub.sub.test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
 
     yield request(app.callback())
-    .get('/referrer/subdomain')
-    .set('referrer', 'https://sub.sub.test1.com/')
-    .expect(403)
-    .expect(/jsonp request security validate failed/);
+      .get('/referrer/subdomain')
+      .set('referrer', 'https://sub.sub.test1.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
   });
 
   it('should pass referrer white list with domain', function* () {
     yield request(app.callback())
-    .get('/referrer/equal')
-    .set('referrer', 'http://test.com/')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/referrer/equal')
+      .set('referrer', 'http://test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
 
     yield request(app.callback())
-    .get('/referrer/equal')
-    .set('referrer', 'https://test.com/')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/referrer/equal')
+      .set('referrer', 'https://test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
 
     yield request(app.callback())
-    .get('/referrer/equal')
-    .set('referrer', 'https://sub.sub.test.com/')
-    .expect(403)
-    .expect(/jsonp request security validate failed/);
+      .get('/referrer/equal')
+      .set('referrer', 'https://sub.sub.test.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
 
     yield request(app.callback())
-    .get('/referrer/equal')
-    .set('referrer', 'https://sub.sub.test1.com/')
-    .expect(403)
-    .expect(/jsonp request security validate failed/);
+      .get('/referrer/equal')
+      .set('referrer', 'https://sub.sub.test1.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
   });
 
   it('should pass referrer white array and regexp', function* () {
     yield request(app.callback())
-    .get('/referrer/regexp')
-    .set('referrer', 'http://test.com/')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/referrer/regexp')
+      .set('referrer', 'http://test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
 
     yield request(app.callback())
-    .get('/referrer/regexp')
-    .set('referrer', 'https://foo.com/')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/referrer/regexp')
+      .set('referrer', 'https://foo.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
 
     yield request(app.callback())
-    .get('/referrer/regexp')
-    .set('referrer', 'https://sub.sub.test.com/')
-    .expect(403)
-    .expect(/jsonp request security validate failed/);
+      .get('/referrer/regexp')
+      .set('referrer', 'https://sub.sub.test.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
 
     yield request(app.callback())
-    .get('/referrer/regexp')
-    .set('referrer', 'https://sub.sub.test1.com/')
-    .expect(403)
-    .expect(/jsonp request security validate failed/);
+      .get('/referrer/regexp')
+      .set('referrer', 'https://sub.sub.test1.com/')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
   });
 
   it('should pass when pass csrf but not hit referrer white list', function* () {
     yield request(app.callback())
-    .get('/both')
-    .set('cookie', 'csrfToken=token;')
-    .set('x-csrf-token', 'token')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/both')
+      .set('cookie', 'csrfToken=token;')
+      .set('x-csrf-token', 'token')
+      .expect(200)
+      .expect({ foo: 'bar' });
   });
 
   it('should pass when not pass csrf but hit referrer white list', function* () {
     yield request(app.callback())
-    .get('/both')
-    .set('referrer', 'https://test.com/')
-    .expect(200)
-    .expect({ foo: 'bar' });
+      .get('/both')
+      .set('referrer', 'https://test.com/')
+      .expect(200)
+      .expect({ foo: 'bar' });
   });
 
   it('should 403 when not pass csrf and not hit referrer white list', function* () {
     yield request(app.callback())
-    .get('/both')
-    .expect(403)
-    .expect(/jsonp request security validate failed/);
+      .get('/both')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
   });
 
   it('should 403 when not pass csrf and referrer illegal', function* () {
     yield request(app.callback())
-    .get('/both')
-    .set('referrer', '/hello')
-    .expect(403)
-    .expect(/jsonp request security validate failed/);
+      .get('/both')
+      .set('referrer', '/hello')
+      .expect(403)
+      .expect(/jsonp request security validate failed/);
   });
 
   it('should pass and return is a jsonp function', function* () {


### PR DESCRIPTION
##### Checklist
- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows commit guidelines

此次改动增加当前请求是否jsonp请求`ctx.acceptJSONP`，以及开放body的jsonp包装方法。
主要是为了解决在error插件中，对jsonp请求无法正确处理结果的问题。其他插件以后或许也能用到相应的api。